### PR TITLE
Fix: Plunger doesn't apply force sometimes

### DIFF
--- a/scenes/plunger.tscn
+++ b/scenes/plunger.tscn
@@ -1,13 +1,13 @@
 [gd_scene load_steps=11 format=3 uid="uid://da7iws7rn34ic"]
 
-[ext_resource type="Script" uid="uid://b3lp8wlfofs6q" path="res://scripts/plunger.gd" id="1_qcbao"]
+[ext_resource type="Script" uid="uid://cjeynbd2h4tfv" path="res://scripts/plunger.gd" id="1_qcbao"]
 [ext_resource type="Texture2D" uid="uid://bditfufxos73q" path="res://assets/sprites/plunger/plunger_sprite_sheet1.png" id="2_1r2yk"]
 [ext_resource type="Texture2D" uid="uid://3v4pt6ssujfq" path="res://assets/sprites/plunger/plunger_sprite_sheet2.png" id="3_kegrl"]
 [ext_resource type="Texture2D" uid="uid://vcutuuc7c8y8" path="res://assets/sprites/plunger/plunger_sprite_sheet3.png" id="4_tsebl"]
 [ext_resource type="Texture2D" uid="uid://bn2bv0fhjfav8" path="res://assets/sprites/plunger/plunger_sprite_sheet4.png" id="5_uj50b"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_1r2yk"]
-bounce = 0.5
+bounce = 0.4
 absorbent = true
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_uj50b"]


### PR DESCRIPTION
## Description
 - Yesterday, we added an absorbent physics material to the plunger so that the ball wouldn't continually bounce on it when it drops down
 - The problem with this is that the force applied by the plunger to the ball is triggered when the ball's physics body enters another.
   - When the ball doesn't bounce on the plunger, this means the ball's physics body has already been in contact with the plunger when it is released
 - Reducing the absorbency of the plunger means that the ball continually bounces on top of the plunger the way it used to, but the bounces are lower than 1 pixel in height and so are not rendered


## Demo

### Before

[old_plunger_test.webm](https://github.com/user-attachments/assets/2d33a83c-c6e8-4a43-a11a-844606f81fe4)

### After

[new_plunger_test.webm](https://github.com/user-attachments/assets/73c4ba3e-5b50-41fd-a44b-625647fcca19)
