### PR TITLE
Fix/ball respawn

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,15 +1,14 @@
-[gd_scene load_steps=14 format=4 uid="uid://bn68c8ajnoa4q"]
+[gd_scene load_steps=13 format=4 uid="uid://bn68c8ajnoa4q"]
 
-[ext_resource type="Script" uid="uid://bstyqnbqjcg4e" path="res://scripts/main.gd" id="1_jyhfs"]
+[ext_resource type="Script" uid="uid://bnx3jrycl4pnd" path="res://scripts/main.gd" id="1_jyhfs"]
 [ext_resource type="PackedScene" uid="uid://bn88swkkd7ayb" path="res://scenes/flipper.tscn" id="2_0wfyh"]
-[ext_resource type="PackedScene" uid="uid://pe12kdi80xnp" path="res://scenes/ball.tscn" id="2_jyhfs"]
-[ext_resource type="Script" uid="uid://c3nh27jiggrxk" path="res://scenes/shake_layer.gd" id="3_choun"]
+[ext_resource type="Script" uid="uid://dpyiews2dok3c" path="res://scenes/shake_layer.gd" id="3_choun"]
 [ext_resource type="TileSet" uid="uid://bwcu4d0i4ii6t" path="res://resources/tilesets/small_tileset.tres" id="4_jyhfs"]
 [ext_resource type="PackedScene" uid="uid://da7iws7rn34ic" path="res://scenes/plunger.tscn" id="5_tbgi4"]
 [ext_resource type="PackedScene" uid="uid://bgaqkaaebb2t2" path="res://scenes/bumper.tscn" id="6_tefeu"]
-[ext_resource type="FontFile" uid="uid://c7v3yvfsc3f3y" path="res://assets/fonts/Beanstalk.ttf" id="7_o6xl0"]
-[ext_resource type="PackedScene" path="res://scenes/triple_rollover_button_group.tscn" id="8_tipki"]
-[ext_resource type="PackedScene" uid="uid://dcmdeefrkityr" path="res://scenes/killzone.tscn" id="9_85g3d"]
+[ext_resource type="FontFile" uid="uid://b86m1rdbbrrm7" path="res://assets/fonts/Beanstalk.ttf" id="7_o6xl0"]
+[ext_resource type="PackedScene" uid="uid://cr2l0w57gwgbl" path="res://scenes/triple_rollover_button_group.tscn" id="8_tipki"]
+[ext_resource type="PackedScene" path="res://scenes/killzone.tscn" id="9_85g3d"]
 [ext_resource type="PackedScene" uid="uid://yy4kt2x5ge2" path="res://scenes/circle_bumper.tscn" id="10_choun"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tefeu"]
@@ -103,12 +102,6 @@ shape = SubResource("RectangleShape2D_choun")
 
 [node name="Balls" type="Node2D" parent="Shake_Layer"]
 unique_name_in_owner = true
-
-[node name="Ball" parent="Shake_Layer/Balls" instance=ExtResource("2_jyhfs")]
-unique_name_in_owner = true
-z_index = 10
-position = Vector2(436, 301.25)
-rotation = 0.0
 
 [node name="CircleBumper" parent="Shake_Layer" instance=ExtResource("10_choun")]
 position = Vector2(311, 112)

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -24,12 +24,13 @@ var multiplier = 1:
 func _ready():
 	%UI/TimerLabel.text = format_time(countdown_time)
 	%Plunger.connect("game_started_signal", _on_game_started_signal)
-	%Ball.connect("modify_score", _modify_score)
+	_create_new_ball()
 
 
 func _create_new_ball():
 	var ball = ball_scene.instantiate()
 	ball.position = NEW_BALL_POSITION
+	ball.connect("modify_score", _modify_score)
 	$Shake_Layer/Balls.add_child(ball)
 
 	

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -77,8 +77,5 @@ func format_time(seconds: int) -> String:
 	
 
 func _on_shake_layer_child_entered_tree(node: Node) -> void:
-	if node is Ball:
-		node.connect("modify_score", _modify_score)
-
 	if node is TripleRolloverButtonGroup:
 		node.connect("modify_multiplier", _modify_multiplier)


### PR DESCRIPTION
## Description
 - Previously, the ball would only respawn one time
 - Previously, only the first ball in play would score points
   - This is fixed by calling `ball.connect("modify_score", _modify_score)` in `_create_new_ball`
   - I removed $Ball from the main scene and called `_create_new_ball()` on startup, so that we consistently connect the "modify_score" signal in the same way

## Demo

### Before

 - the first ball scores points
 - the second ball does not score any points
 - after the second ball dies, a new ball is not created

[before_respawn_demo.webm](https://github.com/user-attachments/assets/c726cbed-5f81-4ab1-8021-b6fdaec9dac1)

### After

 - all balls score points
 - balls are continually created after the previous one dies

[after_respawn_demo.webm](https://github.com/user-attachments/assets/1f7d86e4-8f37-470f-98d8-24a20ff0ac48)
