### PR TITLE
Ball Physics fixes

### DIFF
--- a/scenes/ball.tscn
+++ b/scenes/ball.tscn
@@ -135,6 +135,7 @@ rotation = 6.5973444
 mass = 0.08
 physics_material_override = SubResource("PhysicsMaterial_sugp2")
 gravity_scale = 0.25
+continuous_cd = 2
 contact_monitor = true
 max_contacts_reported = 1
 script = ExtResource("1_cxlvu")

--- a/scripts/ball.gd
+++ b/scripts/ball.gd
@@ -18,21 +18,22 @@ var global_collision_pos : Vector2 = Vector2.ZERO
 
 func _integrate_forces(state: PhysicsDirectBodyState2D) -> void:
 	if state.get_contact_count() > 0:
-		global_collision_pos = state.get_contact_local_position(0)
+		var collider = state.get_contact_collider_object(0)
+
+		if collider.name == "FlipperBodyActive" && collider.get_parent().get_parent() is Flipper:
+			global_collision_pos = state.get_contact_local_position(0)
+			collider.get_parent().get_parent().apply_collision_force(self)
+
+		elif collider.get_parent() is Plunger:
+			collider.get_parent().apply_collision_force(self)
 
 func _on_body_entered(body: Node) -> void:
-	if body.name == "FlipperBodyActive" && body.get_parent().get_parent() is Flipper:
-		body.get_parent().get_parent().apply_collision_force(self)
-	elif body.get_parent() is Bumper && body.name == "Active":
+	if body.get_parent() is Bumper && body.name == "Active":
 		body.get_parent().apply_collision_force(self)
 		modify_score.emit(Bumper.score_value)
 	elif body is CircleBumper:
 		body.apply_collision_force(self)
 		modify_score.emit(CircleBumper.score_value)
-
-
-	elif body.get_parent() is Plunger:
-		body.get_parent().apply_collision_force(self)
 
 func _physics_process(delta: float) -> void:
 	_update_animation_frame()

--- a/scripts/flipper.gd
+++ b/scripts/flipper.gd
@@ -6,7 +6,7 @@ enum FlipperState { IDLE, TRIGGERED, RISING, FALLING }  # Flipper motion phases
 enum FlipperInput { NONE, PRESS, RELEASE }              # Player input events
 
 # --- Constants ---
-const FLIPPER_STRENGTH: float = 50 # the maximum force the flipper can exert
+const FLIPPER_STRENGTH: float = 30 # the maximum force the flipper can exert
 const TRIGGERED_COYOTE_FRAME_MAX: int = 3
 const FLIPPER_LENGTH: int = 24 # approximate length from axle to tip of flipper
 

--- a/scripts/flipper.gd
+++ b/scripts/flipper.gd
@@ -79,8 +79,7 @@ func get_perpendicular_angle():
 	# Flip perpendicular depending on left/right side
 	var perpendicular_angle: float = current_flipper_angle - 90
 	if not left_flipper:
-		perpendicular_angle *= -1
-		perpendicular_angle += 180
+		perpendicular_angle = current_flipper_angle + 90
 		
 	return perpendicular_angle
 

--- a/scripts/plunger.gd
+++ b/scripts/plunger.gd
@@ -1,7 +1,7 @@
 extends Node2D
 class_name Plunger
 
-const PLUNGER_STRENGTH = 30
+const PLUNGER_STRENGTH = 20
 
 # Called when the node enters the scene tree for the first time.
 enum PlungerState { RISING, FALLING, IDLE }  # Plunger motion phases


### PR DESCRIPTION
## Description

 - Prevent undending ball bouncing by enabling "Cast Shape" continuous collision detection mode on the ball
 - Allow flippers and plunger to apply a force whenever in contact with the ball
   - This is done by moving flipper/plunger collision detection to `_integrate_forces`
   - This is necessary because the ball no longer continuously bounces on whatever surface it's on. Because we used to rely on `ball._on_body_entered()` for collision detection, oftentimes the ball's physics body has not just been entered when we want to apply a force
 - Reduce flipper and plunger force, as the flipper/plunger collision detection change makes them feel more powerful

## Misc

 - Fix perpendicular angle calculation for the right flipper. This means that the ball comes off the left flipper and the right flipper in the same way

## Demo

### Before

[ball_physics_before.webm](https://github.com/user-attachments/assets/07d2d4a7-7d70-4f32-ad0c-a1004ea1d6ef)

### After

[ball_physics_after.webm](https://github.com/user-attachments/assets/7645040b-0287-48cb-8658-9b3a60d834b2)
